### PR TITLE
Use new jadx API for icons and usage dialog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,21 +11,11 @@ plugins {
 }
 
 dependencies {
-	val jadxVersion = "1.5.1"
+	val jadxVersion = "1.5.2-SNAPSHOT"
 	val isJadxSnapshot = jadxVersion.endsWith("-SNAPSHOT")
 
 	// use compile only scope to exclude jadx-core and its dependencies from result jar
 	compileOnly("io.github.skylot:jadx-core:$jadxVersion") {
-		isChanging = isJadxSnapshot
-	}
-	compileOnly("io.github.skylot:jadx-gui:$jadxVersion") {
-		isChanging = isJadxSnapshot
-	}
-	// don't know why I need this, but tests fail otherwise
-	testRuntimeOnly("io.github.skylot:jadx-gui:$jadxVersion") {
-		isChanging = isJadxSnapshot
-	}
-	compileOnly("io.github.skylot:jadx-cli:$jadxVersion") {
 		isChanging = isJadxSnapshot
 	}
 

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/NativeLibrariesPlugin.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/NativeLibrariesPlugin.java
@@ -20,6 +20,7 @@ public class NativeLibrariesPlugin implements JadxPlugin {
 				.name("Native Library Info")
 				.description(DESCRIPTION)
 				.homepage("https://github.com/andyjsmith/jadx-native-libraries-plugin")
+				.requiredJadxVersion("1.5.2, r2372")
 				.build();
 	}
 

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/PluginDialog.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/PluginDialog.java
@@ -2,9 +2,6 @@ package org.ajsmith.jadx.plugins.nativelibraries;
 
 import jadx.api.JavaMethod;
 import jadx.api.plugins.JadxPluginContext;
-import jadx.gui.treemodel.JNode;
-import jadx.gui.ui.MainWindow;
-import jadx.gui.ui.dialog.UsageDialog;
 import org.ajsmith.jadx.plugins.nativelibraries.components.NativeMethod;
 import org.ajsmith.jadx.plugins.nativelibraries.components.NativeRoot;
 import org.jetbrains.annotations.Nullable;
@@ -65,7 +62,6 @@ public class PluginDialog extends JDialog {
 		findUsageBtn.setEnabled(false);
 		findUsageBtn.addActionListener(e -> {
 			if (context.getGuiContext() == null) return;
-			MainWindow mw = (MainWindow) context.getGuiContext().getMainFrame();
 
 			TreeNode treeNode = (TreeNode) tree.getLastSelectedPathComponent();
 			if (!(treeNode instanceof NativeMethod)) return;
@@ -76,10 +72,7 @@ public class PluginDialog extends JDialog {
 				showMethodNotFoundDialog(treeNode);
 				return;
 			}
-
-			JNode node = mw.getCacheObject().getNodeCache().makeFrom(javaMethod);
-			if (node == null) return;
-			new UsageDialog(mw, node).setVisible(true);
+			context.getGuiContext().openUsageDialog(javaMethod.getCodeNodeRef());
 		});
 
 		JButton closeBtn = new JButton("Close");

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/PluginOptions.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/PluginOptions.java
@@ -2,8 +2,6 @@ package org.ajsmith.jadx.plugins.nativelibraries;
 
 import jadx.api.plugins.JadxPluginContext;
 import jadx.api.plugins.options.impl.BasePluginOptionsBuilder;
-import jadx.gui.settings.JadxSettings;
-import jadx.gui.ui.MainWindow;
 
 public class PluginOptions extends BasePluginOptionsBuilder {
 	private final JadxPluginContext context;
@@ -15,12 +13,5 @@ public class PluginOptions extends BasePluginOptionsBuilder {
 
 	@Override
 	public void registerOptions() {
-	}
-
-	private void save() {
-		if (context.getGuiContext() == null) return;
-		JadxSettings settings = ((MainWindow) context.getGuiContext().getMainFrame()).getSettings();
-		// save settings here
-		settings.sync();
 	}
 }

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeClass.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeClass.java
@@ -1,6 +1,5 @@
 package org.ajsmith.jadx.plugins.nativelibraries.components;
 
-import jadx.gui.utils.Icons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -61,7 +60,7 @@ public class NativeClass extends NativeObject {
 
 	@Override
 	public @NotNull ImageIcon getIcon() {
-		return Icons.CLASS;
+		return getGuiContext().getSVGIcon("nodes/class");
 	}
 
 	@Override

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeLibrary.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeLibrary.java
@@ -3,7 +3,6 @@ package org.ajsmith.jadx.plugins.nativelibraries.components;
 import jadx.api.ResourceFile;
 import jadx.api.ResourcesLoader;
 import jadx.core.utils.exceptions.JadxException;
-import jadx.gui.utils.UiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +16,6 @@ import java.util.Enumeration;
 import java.util.List;
 
 public class NativeLibrary extends NativeObject {
-	private static final ImageIcon SO_ICON = UiUtils.openSvgIcon("nodes/binaryFile");
 	private final String libraryName;
 	private final NativeRoot root;
 	private final List<NativePackage> packages = new ArrayList<>();
@@ -144,7 +142,7 @@ public class NativeLibrary extends NativeObject {
 
 	@Override
 	public @NotNull ImageIcon getIcon() {
-		return SO_ICON;
+		return root.getGuiContext().getSVGIcon("nodes/binaryFile");
 	}
 
 	@Override

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeMethod.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeMethod.java
@@ -4,7 +4,6 @@ import jadx.api.JavaClass;
 import jadx.api.JavaMethod;
 import jadx.api.JavaPackage;
 import jadx.core.utils.exceptions.DecodeException;
-import jadx.gui.utils.Icons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
@@ -275,7 +274,7 @@ public class NativeMethod extends NativeObject {
 
 	@Override
 	public @Nullable ImageIcon getIcon() {
-		return Icons.METHOD;
+		return getGuiContext().getSVGIcon("nodes/method");
 	}
 
 	@Override

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeObject.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeObject.java
@@ -1,11 +1,13 @@
 package org.ajsmith.jadx.plugins.nativelibraries.components;
 
 import jadx.api.plugins.JadxPluginContext;
+import jadx.api.plugins.gui.JadxGuiContext;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.ImageIcon;
 import javax.swing.tree.TreeNode;
+import java.util.Objects;
 
 public abstract class NativeObject implements TreeNode {
 	protected static final String JAVA_PREFIX = "Java_";
@@ -54,5 +56,9 @@ public abstract class NativeObject implements TreeNode {
 	public @Nullable JadxPluginContext getContext() {
 		if (getParent() == null) return null;
 		return getParent().getContext();
+	}
+
+	public @NotNull JadxGuiContext getGuiContext() {
+		return getContext().getGuiContext();
 	}
 }

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativePackage.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativePackage.java
@@ -1,6 +1,5 @@
 package org.ajsmith.jadx.plugins.nativelibraries.components;
 
-import jadx.gui.utils.Icons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -115,7 +114,7 @@ public class NativePackage extends NativeObject {
 
 	@Override
 	public @NotNull ImageIcon getIcon() {
-		return Icons.PACKAGE;
+		return getGuiContext().getSVGIcon("nodes/package");
 	}
 
 	@Override

--- a/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeRoot.java
+++ b/src/main/java/org/ajsmith/jadx/plugins/nativelibraries/components/NativeRoot.java
@@ -3,6 +3,7 @@ package org.ajsmith.jadx.plugins.nativelibraries.components;
 import jadx.api.ResourceFile;
 import jadx.api.ResourceType;
 import jadx.api.plugins.JadxPluginContext;
+import jadx.api.plugins.gui.JadxGuiContext;
 import net.fornwall.jelf.ElfFile;
 import net.fornwall.jelf.ElfSymbol;
 import org.jetbrains.annotations.NotNull;
@@ -18,6 +19,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 
 public class NativeRoot extends NativeObject {
 	private static final Logger LOG = LoggerFactory.getLogger(NativeRoot.class);
@@ -75,6 +77,11 @@ public class NativeRoot extends NativeObject {
 	@Override
 	public JadxPluginContext getContext() {
 		return context;
+	}
+
+	@Override
+	public @NotNull JadxGuiContext getGuiContext() {
+		return Objects.requireNonNull(context.getGuiContext());
 	}
 
 	@Override


### PR DESCRIPTION
I implemented new API methods to get jadx icons and open usage dialog.

Hope I correctly get a gui context in tree nodes, not sure for what cases parent can be null, please verify this :slightly_smiling_face:

Also, these changes will work only for unstable jadx version (from [here](https://nightly.link/skylot/jadx/workflows/build-artifacts/master)), but even if you release it right now, latest stable version of jadx (1.5.1) should skip incompatible release and install previous one (thanks to `.requiredJadxVersion("1.5.2, r2372")` part in plugin info).